### PR TITLE
Added a workaround for an xunit multiple enumerate issue.

### DIFF
--- a/sources/core/Stride.Core.Yaml.Tests/InsertionQueueTests.cs
+++ b/sources/core/Stride.Core.Yaml.Tests/InsertionQueueTests.cs
@@ -78,7 +78,7 @@ namespace Stride.Core.Yaml.Tests
 
             WithTheRange(0, 10).Perform(queue.Enqueue);
 
-            Assert.Equal(new List<int>() {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, OrderOfElementsIn(queue));
+            Assert.Equal(new List<int>() {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, OrderOfElementsIn(queue).ToList());
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace Stride.Core.Yaml.Tests
             PerformTimes(5, queue.Dequeue);
             WithTheRange(10, 15).Perform(queue.Enqueue);
 
-            Assert.Equal(new List<int>() {5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, OrderOfElementsIn(queue));
+            Assert.Equal(new List<int>() {5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, OrderOfElementsIn(queue).ToList());
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace Stride.Core.Yaml.Tests
             WithTheRange(0, 10).Perform(queue.Enqueue);
             queue.Insert(5, 99);
 
-            Assert.Equal(new List<int>() {0, 1, 2, 3, 4, 99, 5, 6, 7, 8, 9}, OrderOfElementsIn(queue));
+            Assert.Equal(new List<int>() {0, 1, 2, 3, 4, 99, 5, 6, 7, 8, 9}, OrderOfElementsIn(queue).ToList());
         }
 
         private static InsertionQueue<int> CreateQueue()


### PR DESCRIPTION
# PR Details

Solidified the results of an enumerable to fix a failure due to xunit enumerating the enumerable multiple times.

This is being added as a pull request in a very strange place, I hope it's OK with you that I make this towards your personal fork.

## Description

The enumerable used in these cases is mutation (pretty much GetConsumingEnumerable from a blocking collection). However, with a change in xunit the `Assert.Equal` method now enumerates collections multiple times. The first enumerate gets the items, then the second fails because there's nothing left to give.

To work around this, the collections are now solidified before being compared, so multiple enumeration is no longer an issue.

The solidification method could be ToArray, I did verify it can work with either (It's checking items, not wrapper types).

## Related Issue

https://github.com/xunit/xunit/issues/2402

## Motivation and Context

It fixes the unit tests.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] My change requires a change to the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.